### PR TITLE
Updated test project structure and refactored tests

### DIFF
--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityCore.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityCore.groovy
@@ -7,6 +7,7 @@ import spock.lang.Specification
 import static org.gradle.testkit.runner.TaskOutcome.*
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import static net.serenitybdd.modules.utils.Projects.*
 
 public class WhenBuildingSerenityCore extends Specification {
 
@@ -16,7 +17,7 @@ public class WhenBuildingSerenityCore extends Specification {
     def "serenity-core tests should build successfully"() {
         given:
             def File location = temporary.getRoot()
-            def core = new ProjectBuildHelper(project: "serenity-core").prepareProject(location)
+            def core = new ProjectBuildHelper(project: SERENITY_CORE).prepareProject(location)
         when:
             def result = GradleRunner.create().forwardOutput()
                 .withProjectDir(core)

--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityCucumber.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityCucumber.groovy
@@ -11,6 +11,7 @@ import spock.lang.Specification
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static net.serenitybdd.modules.utils.Projects.*
 
 /**
  * User: YamStranger
@@ -25,8 +26,8 @@ class WhenBuildingSerenityCucumber extends Specification {
     def "serenity-cucumber tests should work with last changes in serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-cucumber").prepareProject(location)
-            def version = ProjectDependencyHelper.publish("serenity-core", location)
+            def project = new ProjectBuildHelper(project: SERENITY_CUCUMBER).prepareProject(location)
+            def version = ProjectDependencyHelper.publish(SERENITY_CORE, location)
             new BuildScriptHelper(project: project).updateVersionOfSerenityCore(version)
         when:
             def result = GradleRunner.create().forwardOutput()
@@ -41,7 +42,7 @@ class WhenBuildingSerenityCucumber extends Specification {
     def "serenity-cucumber tests should execute successfully with latest published serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-cucumber").prepareProject(location)
+            def project = new ProjectBuildHelper(project: SERENITY_CUCUMBER).prepareProject(location)
         when:
             def result = GradleRunner.create().forwardOutput()
                 .withProjectDir(project)

--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityJBehave.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityJBehave.groovy
@@ -11,6 +11,7 @@ import spock.lang.Specification
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static net.serenitybdd.modules.utils.Projects.*
 
 /**
  * User: YamStranger
@@ -26,8 +27,8 @@ class WhenBuildingSerenityJBehave extends Specification {
     def "serenity-jbehave tests should work with last changes in serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-jbehave").prepareProject(location)
-            def version = ProjectDependencyHelper.publish("serenity-core", location)
+            def project = new ProjectBuildHelper(project: SERENITY_JBEHAVE).prepareProject(location)
+            def version = ProjectDependencyHelper.publish(SERENITY_CORE, location)
             new BuildScriptHelper(project: project).updateVersionOfSerenityCore(version)
 
         when:
@@ -43,7 +44,7 @@ class WhenBuildingSerenityJBehave extends Specification {
     def "serenity-jbehave tests should execute successfully with latest published serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-jbehave").prepareProject(location)
+            def project = new ProjectBuildHelper(project: SERENITY_JBEHAVE).prepareProject(location)
         when:
             def result = GradleRunner.create().forwardOutput()
                 .withProjectDir(project)

--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityJIRA.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityJIRA.groovy
@@ -10,6 +10,7 @@ import spock.lang.Specification
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static net.serenitybdd.modules.utils.Projects.*
 
 /**
  * User: YamStranger
@@ -24,8 +25,8 @@ class WhenBuildingSerenityJIRA extends Specification {
     def "serenity-jira tests should work with last changes in serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-jira").prepareProject(location)
-            def version = ProjectDependencyHelper.publish("serenity-core", location)
+            def project = new ProjectBuildHelper(project: SERENITY_JIRA).prepareProject(location)
+            def version = ProjectDependencyHelper.publish(SERENITY_CORE, location)
             new BuildScriptHelper(project: project).updateVersionOfSerenityCore(version)
         when:
             def result = GradleRunner.create().forwardOutput()
@@ -39,7 +40,7 @@ class WhenBuildingSerenityJIRA extends Specification {
     def "serenity-jira tests should execute successfully with latest published serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-jira").prepareProject(location)
+            def project = new ProjectBuildHelper(project: SERENITY_JIRA).prepareProject(location)
         when:
             def result = GradleRunner.create().forwardOutput()
                 .withProjectDir(project)

--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityMavenPlugin.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingSerenityMavenPlugin.groovy
@@ -11,6 +11,7 @@ import spock.lang.Specification
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static net.serenitybdd.modules.utils.Projects.*
 
 /**
  * User: YamStranger
@@ -25,8 +26,8 @@ class WhenBuildingSerenityMavenPlugin extends Specification {
     def "serenity-maven-plugin tests should work with last changes in serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-maven-plugin").prepareProject(location)
-            def version = ProjectDependencyHelper.publish("serenity-core", location)
+            def project = new ProjectBuildHelper(project: SERENITY_MAVEN_PLUGIN).prepareProject(location)
+            def version = ProjectDependencyHelper.publish(SERENITY_CORE, location)
             new BuildScriptHelper(project: project).updateVersionOfSerenityCore(version)
         when:
             def result = GradleRunner.create().forwardOutput()
@@ -41,7 +42,7 @@ class WhenBuildingSerenityMavenPlugin extends Specification {
     def "serenity-maven-plugin tests should execute successfully with latest published serenity modules"() {
         given:
             def File location = temporary.getRoot()
-            def project = new ProjectBuildHelper(project: "serenity-maven-plugin").prepareProject(location)
+            def project = new ProjectBuildHelper(project: SERENITY_MAVEN_PLUGIN).prepareProject(location)
         when:
             def result = GradleRunner.create().forwardOutput()
                 .withProjectDir(project)

--- a/src/test/groovy/net/serenitybdd/modules/utils/Project.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/utils/Project.groovy
@@ -1,0 +1,28 @@
+package net.serenitybdd.modules.utils
+
+import net.thucydides.core.reports.OutcomeFormat
+import net.thucydides.core.reports.TestOutcomeLoader
+import net.thucydides.core.reports.TestOutcomes
+
+/**
+ * User: YamStranger
+ * Date: 2/20/16
+ * Time: 1:11 PM
+ */
+class Project {
+    def String name
+    def File root
+    def File reports
+    def Map<String, Project> modules
+
+    def public Project(def String name, def File root) {
+        this.name = name
+        this.root = root
+        this.reports = reports
+        modules = new HashMap<>()
+    }
+
+    def public TestOutcomes reports(def OutcomeFormat format) {
+        TestOutcomeLoader.loadTestOutcomes().inFormat(format).from(reports);
+    }
+}

--- a/src/test/groovy/net/serenitybdd/modules/utils/Projects.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/utils/Projects.groovy
@@ -1,0 +1,28 @@
+package net.serenitybdd.modules.utils
+
+/**
+ * User: YamStranger
+ * Date: 2/20/16
+ * Time: 2:51 PM
+ */
+enum Projects {
+
+    SERENITY_TEST_PROJECTS("serenity-test-projects"),
+    SERENITY_JBEHAVE("serenity-jbehave"),
+    SERENITY_CUCUMBER("serenity-cucumber"),
+    SERENITY_CORE("serenity-core"),
+    SERENITY_JIRA("serenity-jira"),
+    SERENITY_MAVEN_PLUGIN("serenity-maven-plugin"),
+    WEB_TODOMVC_TESTS("$SERENITY_TEST_PROJECTS/web-todomvc-tests")
+
+    def final private String name
+
+    public Projects(def name) {
+        this.name = name
+    }
+
+    @Override
+    String toString() {
+        return name
+    }
+}

--- a/src/test/groovy/net/serenitybdd/modules/utils/TreeCopier.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/utils/TreeCopier.groovy
@@ -1,5 +1,6 @@
 package net.serenitybdd.modules.utils
 
+import org.apache.commons.io.FileUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.nio.file.FileAlreadyExistsException
@@ -38,6 +39,8 @@ class TreeCopier implements FileVisitor<Path> {
             return FileVisitResult.SKIP_SUBTREE;
         }
         Path newdir = target.resolve(source.relativize(dir));
+        FileUtils.deleteDirectory(newdir.toFile())
+        Files.createDirectories(newdir)
         try {
             Files.copy(dir, newdir, StandardCopyOption.REPLACE_EXISTING);
         } catch (FileAlreadyExistsException x) {


### PR DESCRIPTION
#### Summary of this PR

Updating test project structure, moving test projects against todomvc to separate dir. Refactored tests to have enum with all paths to subprojects 
#### Intended effect

Now we can have several tests projects ans easily move test projects to different directorates 
#### How should this be manually tested?

Nothing should be changed, build should work as before
#### Side effects

N/A
#### Documentation

N/A
#### Relevant tickets

N/A
#### Screenshots (if appropriate)

N/A
