### PR TITLE
Added tests for for parallel executions of jbehave and jbehave tag usage tests

### DIFF
--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingJBehaveTestProject.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingJBehaveTestProject.groovy
@@ -1,0 +1,65 @@
+package net.serenitybdd.modules
+
+import net.serenitybdd.modules.utils.*
+import net.thucydides.core.reports.OutcomeFormat
+import net.thucydides.core.reports.TestOutcomeLoader
+import org.gradle.testkit.runner.GradleRunner
+import org.hamcrest.Matchers
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.nio.file.Path
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+
+import static net.serenitybdd.modules.utils.Projects.*
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+
+/**
+ * User: YamStranger
+ * Date: 1/31/16
+ * Time: 2:07 AM
+ */
+class WhenBuildingJBehaveTestProject extends Specification {
+
+    @Rule
+    final TemporaryFolder temporary = new TemporaryFolder()
+
+    def "jbeahve-tags test project report should contains correct number of manual tests"() {
+        given:
+            def File location = temporary.getRoot()
+            def coreVersion = ProjectDependencyHelper.publish(SERENITY_CORE, location)
+
+            def ExecutorService service = new TestThreadExecutorService().getExecutorService();
+            def jbehaveFeature = service.submit(new Callable() {
+                @Override
+                String call() throws Exception {
+                    ProjectDependencyHelper.publish(SERENITY_JBEHAVE, location, { it ->
+                        new BuildScriptHelper(project: it).updateVersionOfSerenityCore(coreVersion)
+                    })
+                }
+            })
+
+            def testProject = service.submit(new Callable() {
+                @Override
+                File call() throws Exception {
+                    new ProjectBuildHelper(project: JBEHAVE_TAGS).prepareProject(location)
+                }
+            })
+
+            def project = (File) testProject.get()
+            new BuildScriptHelper(project: project).updateVersionOfSerenityCore(coreVersion)
+                .updateVersionOfSerenityJBehave((String) jbehaveFeature.get())
+        when:
+            def result = GradleRunner.create().forwardOutput()
+                .withProjectDir(project)
+                .withArguments('clean', 'test', 'aggregate')
+                .build()
+            def output = project.toPath().resolve("target").resolve("site").resolve("serenity").toFile()
+            def outcomes = TestOutcomeLoader.loadTestOutcomes().inFormat(OutcomeFormat.JSON).from(output);
+        then:
+            outcomes.getTests().size() == 11
+            outcomes.getOutcomes().findAll({ it -> it.isManual() }).size() == 10
+    }
+}

--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingJBehaveTestsInParallel.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingJBehaveTestsInParallel.groovy
@@ -1,0 +1,104 @@
+package net.serenitybdd.modules
+
+import net.serenitybdd.modules.utils.BuildScriptHelper
+import net.serenitybdd.modules.utils.ProjectBuildHelper
+import net.serenitybdd.modules.utils.ProjectDependencyHelper
+import net.serenitybdd.modules.utils.TestThreadExecutorService
+import net.thucydides.core.reports.OutcomeFormat
+import net.thucydides.core.reports.TestOutcomeLoader
+import org.apache.commons.io.FileUtils
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+
+import static net.serenitybdd.modules.utils.Projects.*
+
+/**
+ * User: YamStranger
+ * Date: 1/31/16
+ * Time: 2:07 AM
+ */
+class WhenBuildingJBehaveTestsInParallel extends Specification {
+
+    @Rule
+    final TemporaryFolder temporary = new TemporaryFolder()
+
+    def "jbeahve module should have ability to work in parallel"() {
+        given:
+            def File location = temporary.getRoot()
+            def coreVersion = ProjectDependencyHelper.publish(SERENITY_CORE, location)
+
+            def ExecutorService service = new TestThreadExecutorService().getExecutorService();
+            def jbehaveFeature = service.submit(new Callable() {
+                @Override
+                String call() throws Exception {
+                    ProjectDependencyHelper.publish(SERENITY_JBEHAVE, location, { it ->
+                        new BuildScriptHelper(project: it).updateVersionOfSerenityCore(coreVersion)
+                    })
+                }
+            })
+
+            def testProject = service.submit(new Callable() {
+                @Override
+                File call() throws Exception {
+                    new ProjectBuildHelper(project: JBEHAVE_IN_PARALLEL).prepareProject(location)
+                }
+            })
+
+            def project = (File) testProject.get()
+            new BuildScriptHelper(project: project).updateVersionOfSerenityCore(coreVersion)
+                .updateVersionOfSerenityJBehave((String) jbehaveFeature.get())
+        when:
+            def File classFile = project.toPath()
+                .resolve("src")
+                .resolve("test")
+                .resolve("java")
+                .resolve("net")
+                .resolve("serenitybdd")
+                .resolve("demos")
+                .resolve("actions")
+                .resolve("UserCanPerformSimpleActionNumber.java").toFile()
+            def File story = project.toPath()
+                .resolve("src")
+                .resolve("test")
+                .resolve("resources")
+                .resolve("stories")
+                .resolve("single_operations")
+                .resolve("user_can_perform_simple_action_number.story").toFile()
+            generateTestClasses(classFile, story, 100)
+            GradleRunner.create().forwardOutput()
+                .withProjectDir(project)
+                .withArguments('clean', 'test', 'aggregate')
+                .build()
+            def output = project.toPath().resolve("target").resolve("site").resolve("serenity").toFile()
+            def outcomes = TestOutcomeLoader.loadTestOutcomes().inFormat(OutcomeFormat.JSON).from(output);
+        then:
+            outcomes.getTests().size() == (100 + 1)
+    }
+
+    private def static generateTestClasses(final File classFile, final File story, final int amount) {
+        amount.times { number ->
+            def createdClass = new File(classFile.getAbsolutePath().replace("Number.java", "Number${number}.java"))
+            def List<String> lines = classFile.readLines("UTF-8")
+            createdClass.withWriter { w ->
+                lines.each { line ->
+                    w.write(line.replace("Number extends", "Number${number} extends"))
+                }
+                w.flush()
+            }
+            def createdStory = new File(story.getAbsolutePath().replace("number.story", "number_${number}.story"))
+            lines = story.readLines("UTF-8")
+            createdStory.withWriter { w ->
+                lines.each { line ->
+                    w.write(line.replace("scenario number", "scenario number ${number}"))
+                }
+                w.flush()
+            }
+        }
+    }
+}

--- a/src/test/groovy/net/serenitybdd/modules/utils/BuildScriptHelper.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/utils/BuildScriptHelper.groovy
@@ -38,7 +38,11 @@ class BuildScriptHelper {
         rewriteLines(buildFile, ["\${serenityCoreVersion}"                : "$version",
                                  "\${project.serenityCoreVersion}"        : "$version",
                                  "\${serenityGradlePluginVersion}"        : "$version",
-                                 "\${project.serenityGradlePluginVersion}": "$version"
+                                 "\${project.serenityGradlePluginVersion}": "$version",
+                                 "\$serenityCoreVersion"                  : "$version",
+                                 "\$project.serenityCoreVersion"          : "$version",
+                                 "\$serenityGradlePluginVersion"          : "$version",
+                                 "\$project.serenityGradlePluginVersion"  : "$version"
         ])
         this
     }
@@ -48,7 +52,8 @@ class BuildScriptHelper {
             throw new IllegalArgumentException("Project should be specified")
         }
         def File buildFile = new File(project, "build.gradle")
-        rewriteLines(buildFile, ["\${serenityCucumberVersion}": "$version"])
+        rewriteLines(buildFile, ["\${serenityCucumberVersion}": "$version",
+                                 "\$serenityCucumberVersion"  : "$version"])
         this
     }
 
@@ -57,7 +62,8 @@ class BuildScriptHelper {
             throw new IllegalArgumentException("Project should be specified")
         }
         def File buildFile = new File(project, "build.gradle")
-        rewriteLines(buildFile, ["\${serenityJBehaveVersion}": "$version"])
+        rewriteLines(buildFile, ["\${serenityJBehaveVersion}": "$version",
+                                 "\$serenityJBehaveVersion"  : "$version"])
         this
     }
 

--- a/src/test/groovy/net/serenitybdd/modules/utils/Projects.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/utils/Projects.groovy
@@ -13,7 +13,9 @@ enum Projects {
     SERENITY_CORE("serenity-core"),
     SERENITY_JIRA("serenity-jira"),
     SERENITY_MAVEN_PLUGIN("serenity-maven-plugin"),
-    WEB_TODOMVC_TESTS("$SERENITY_TEST_PROJECTS/web-todomvc-tests")
+    WEB_TODOMVC_TESTS("$SERENITY_TEST_PROJECTS/web-todomvc-tests"),
+    JBEHAVE_TAGS("$SERENITY_TEST_PROJECTS/jbehave-tags"),
+    JBEHAVE_IN_PARALLEL("$SERENITY_TEST_PROJECTS/jbehave-in-parallel")
 
     def final private String name
 


### PR DESCRIPTION
#### Summary of this PR

Added tests for parallel executions of jbehave and jbehave tag usage tests
#### Intended effect

Now it is possible test how jbehave generate reports when tag are used. Also created test and project that generate some sources (java class and jbehave story) to execute them in parallel (with big gradle forked processes)
#### How should this be manually tested?

All tests can be executed by providing their name during running gradlew clean test
#### Side effects

paralell test can take huge amount of resources
#### Documentation

N/A
#### Relevant tickets

serenity-bdd/serenity-jbehave/issues/45
https://github.com/serenity-bdd/serenity-jbehave/issues/43
#### Screenshots (if appropriate)

N/A
