### PR TITLE
Updated tests to enable parallel testing of jbehave and junit

### DIFF
--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingJBehaveTestsInParallel.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingJBehaveTestsInParallel.groovy
@@ -70,7 +70,9 @@ class WhenBuildingJBehaveTestsInParallel extends Specification {
                 .resolve("stories")
                 .resolve("single_operations")
                 .resolve("user_can_perform_simple_action_number.story").toFile()
-            generateTestClasses(classFile, story, 100)
+
+            def amount = Runtime.runtime.availableProcessors() * 3
+            generateTestClasses(classFile, story, amount)
             GradleRunner.create().forwardOutput()
                 .withProjectDir(project)
                 .withArguments('clean', 'test', 'aggregate')
@@ -78,7 +80,7 @@ class WhenBuildingJBehaveTestsInParallel extends Specification {
             def output = project.toPath().resolve("target").resolve("site").resolve("serenity").toFile()
             def outcomes = TestOutcomeLoader.loadTestOutcomes().inFormat(OutcomeFormat.JSON).from(output);
         then:
-            outcomes.getTests().size() == (100 + 1)
+            outcomes.getTests().size() == (amount + 1)
     }
 
     private def static generateTestClasses(final File classFile, final File story, final int amount) {
@@ -87,7 +89,7 @@ class WhenBuildingJBehaveTestsInParallel extends Specification {
             def List<String> lines = classFile.readLines("UTF-8")
             createdClass.withWriter { w ->
                 lines.each { line ->
-                    w.write(line.replace("Number extends", "Number${number} extends"))
+                    w.write(line.replace("Number extends", "Number${number} extends") + "\n")
                 }
                 w.flush()
             }
@@ -95,7 +97,7 @@ class WhenBuildingJBehaveTestsInParallel extends Specification {
             lines = story.readLines("UTF-8")
             createdStory.withWriter { w ->
                 lines.each { line ->
-                    w.write(line.replace("scenario number", "scenario number ${number}"))
+                    w.write(line.replace("scenario number", "scenario number ${number}") + "\n")
                 }
                 w.flush()
             }

--- a/src/test/groovy/net/serenitybdd/modules/WhenBuildingJUnitTestsInParallel.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/WhenBuildingJUnitTestsInParallel.groovy
@@ -1,0 +1,90 @@
+package net.serenitybdd.modules
+
+import net.serenitybdd.modules.utils.BuildScriptHelper
+import net.serenitybdd.modules.utils.ProjectBuildHelper
+import net.serenitybdd.modules.utils.ProjectDependencyHelper
+import net.serenitybdd.modules.utils.TestThreadExecutorService
+import net.thucydides.core.reports.OutcomeFormat
+import net.thucydides.core.reports.TestOutcomeLoader
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+
+import static net.serenitybdd.modules.utils.Projects.*
+
+/**
+ * User: YamStranger
+ * Date: 1/31/16
+ * Time: 2:07 AM
+ */
+class WhenBuildingJUnitTestsInParallel extends Specification {
+
+    @Rule
+    final TemporaryFolder temporary = new TemporaryFolder()
+
+    def "jbeahve module should have ability to work in parallel"() {
+        given:
+            def File location = stemporary.getRoot()
+            def coreVersion = ProjectDependencyHelper.publish(SERENITY_CORE, location)
+
+            def ExecutorService service = new TestThreadExecutorService().getExecutorService();
+            def jbehaveFeature = service.submit(new Callable() {
+                @Override
+                String call() throws Exception {
+                    ProjectDependencyHelper.publish(SERENITY_JBEHAVE, location, { it ->
+                        new BuildScriptHelper(project: it).updateVersionOfSerenityCore(coreVersion)
+                    })
+                }
+            })
+
+            def testProject = service.submit(new Callable() {
+                @Override
+                File call() throws Exception {
+                    new ProjectBuildHelper(project: JUNIT_IN_PARALLEL).prepareProject(location)
+                }
+            })
+
+            def project = (File) testProject.get()
+            new BuildScriptHelper(project: project).updateVersionOfSerenityCore(coreVersion)
+                .updateVersionOfSerenityJBehave((String) jbehaveFeature.get())
+        when:
+            def File classFile = project.toPath()
+                .resolve("src")
+                .resolve("test")
+                .resolve("java")
+                .resolve("net")
+                .resolve("serenitybdd")
+                .resolve("demos")
+                .resolve("actions")
+                .resolve("UserCanPerformSimpleActionNumber.java").toFile()
+            def amount = Runtime.runtime.availableProcessors() * 3
+            generateTestClasses(classFile, amount)
+            GradleRunner.create().forwardOutput()
+                .withProjectDir(project)
+                .withArguments('clean', 'test', 'aggregate')
+                .build()
+            def output = project.toPath().resolve("target").resolve("site").resolve("serenity").toFile()
+            def outcomes = TestOutcomeLoader.loadTestOutcomes().inFormat(OutcomeFormat.JSON).from(output);
+        then:
+            outcomes.getTests().size() == (amount + 1)
+    }
+
+    private def static generateTestClasses(final File classFile, final int amount) {
+        amount.times { number ->
+            def createdClass = new File(classFile.getAbsolutePath().replace("Number.java", "Number${number}.java"))
+            def List<String> lines = classFile.readLines("UTF-8")
+            createdClass.withWriter { w ->
+                lines.each { line ->
+                    w.write(line
+                        .replace("UserCanPerformSimpleActionNumber", "UserCanPerformSimpleActionNumber${number}")
+                        .replace("do_some_action_number", "do_some_action_number_${number}") + "\n")
+                }
+                w.flush()
+            }
+        }
+    }
+}

--- a/src/test/groovy/net/serenitybdd/modules/utils/Projects.groovy
+++ b/src/test/groovy/net/serenitybdd/modules/utils/Projects.groovy
@@ -15,7 +15,8 @@ enum Projects {
     SERENITY_MAVEN_PLUGIN("serenity-maven-plugin"),
     WEB_TODOMVC_TESTS("$SERENITY_TEST_PROJECTS/web-todomvc-tests"),
     JBEHAVE_TAGS("$SERENITY_TEST_PROJECTS/jbehave-tags"),
-    JBEHAVE_IN_PARALLEL("$SERENITY_TEST_PROJECTS/jbehave-in-parallel")
+    JBEHAVE_IN_PARALLEL("$SERENITY_TEST_PROJECTS/jbehave-in-parallel"),
+    JUNIT_IN_PARALLEL("$SERENITY_TEST_PROJECTS/junit-in-parallel")
 
     def final private String name
 


### PR DESCRIPTION
#### Summary of this PR

Updated tests to run test projects with a lot of tests using junit and jbehave in parallel to check how serenity modules works
#### Intended effect

There are two new tests that should check if reports are generated correctly when tests are executed in parallel
#### How should this be manually tested?

build should be executed for WhenBuildingJBehaveTestsInParallel or WhenBuildingJUnitTestsInParallel
#### Side effects

N/A
#### Documentation

N/A
#### Relevant tickets

serenity-bdd/serenity-jbehave/issues/45
#### Screenshots (if appropriate)

Here is example of generated report for Junit tests
![junit_parallel](https://cloud.githubusercontent.com/assets/1667699/13245157/fdc5ab7a-da13-11e5-888d-7c5c3bff5df2.png)
